### PR TITLE
Change Unique(..., return_counts = T) to Table()

### DIFF
--- a/coroICA/R/coroICA.R
+++ b/coroICA/R/coroICA.R
@@ -189,7 +189,7 @@ coroICA <- function(X,
 
   # generate partiton indices as needed
   if(!is.numeric(partition_index) & is.na(partitionsize)){
-    smallest_group <- min(unique(group_index, return_counts=TRUE)$counts)
+    smallest_group <- min(table(group_index))
     partition_indices <- list(rigidpartition(group_index,
                                            max(c(d, floor(smallest_group/2)))))
   }


### PR DESCRIPTION
Fix bug if neither partition_index or partitionsize is set.
A 'return_counts' argument was used in 'unique',
but this is an argument for np.unique from python.

Signed-off-by: Stefan B. Rasmussen <smj572@alumni.ku.dk>